### PR TITLE
Add initial API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ pnpm build
 
 Entry point is `<root>/lib.ts`. It exports all finished artworks along with a `Sketch` class for embedding sketches in pages
 
-**TODO:** Generate JSDoc
+Documentation for the public API is available in the [`docs`](docs/README.md) directory.
 
 ## Directory structure
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,19 @@
+# API Documentation
+
+This document provides an overview of the public API exported by `@codedpalette/sketches`.
+
+## SketchModule
+Defines metadata for a sketch. It includes a `name` and a `year` indicating where the sketch can be loaded from.
+
+## loadModule
+`loadModule(module: SketchModule): Promise<SketchConstructor>` dynamically imports the module for the specified sketch and returns a factory function for creating it.
+
+## screensaver
+`screensaver(canvas: HTMLCanvasElement)` loads the screensaver sketch and attaches it to the provided canvas element.
+
+## initRenderer
+`initRenderer(params?: Partial<RenderParams<C>>)` initializes a renderer with optional parameters such as size or canvas.
+
+## SketchRunner
+`SketchRunner` is a utility class that controls the render loop and user interactions for a sketch.
+


### PR DESCRIPTION
## Summary
- add API documentation outlining SketchModule, core loaders, and helpers
- link docs from README

## Testing
- `pnpm exec eslint README.md docs/README.md`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689c3a5d6d1c8329885632f93611ade4